### PR TITLE
Refactor HTTP listener to track ingested metadata and replay salts

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,8 +9,8 @@ static HTTP_CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
 pub(super) struct Salts {
     pub(super) match_id: u64,
     cluster_id: u32,
-    metadata_salt: Option<u32>,
-    replay_salt: Option<u32>,
+    pub(super) metadata_salt: Option<u32>,
+    pub(super) replay_salt: Option<u32>,
 }
 
 impl Salts {


### PR DESCRIPTION
This pull request refines how the ingestion process tracks and deduplicates HTTP payloads related to match metadata and replay data. Instead of using a single set to track all ingested matches, it now uses separate sets for metadata and replay, allowing for more granular deduplication and logging. Additionally, visibility of the `metadata_salt` and `replay_salt` fields in the `Salts` struct is increased for broader access.

**Improvements to ingestion deduplication logic:**

* Replaced the single `ingested_matches` set with two sets: `ingested_metadata` and `ingested_replay`, enabling separate tracking of ingested metadata and replay payloads. This allows for more precise deduplication and logging of already ingested data. [[1]](diffhunk://#diff-8b1e2d5072b35608f50fa5b7b0cea3d0bc088ad4f2b720a18cd2ff2cf775f481L16-R17) [[2]](diffhunk://#diff-8b1e2d5072b35608f50fa5b7b0cea3d0bc088ad4f2b720a18cd2ff2cf775f481L27-R65)
* Updated the logic to check and insert into the new sets, and to clear each set independently when it grows too large.

**Struct visibility changes:**

* Changed the visibility of the `metadata_salt` and `replay_salt` fields in the `Salts` struct from private to `pub(super)`, allowing them to be accessed within the current crate for improved flexibility.