### PR TITLE
Add NixOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ sudo ./install-linux.sh
 
 > **Note**: The installation scripts automatically download the latest release binaries from GitHub and set up the application as a system service.
 
+### NixOS
+
+You can add it as a flake and add systemd service files so it will run on boot, or simply run the binary whenever you need it
+
+```
+sudo nix run github:deadlock-api/deadlock-api-ingest
+```
+
 ## Uninstallation
 
 ### Windows

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ pkgs.stdenv.mkDerivation rec {
   version = "0.1.140-8659e00";
 
   src = pkgs.fetchurl {
-    url = "https://github.com/deadlock-api/deadlock-api-ingest/releases/tag/v${version}/deadlock-api-ingest-ubuntu-latest";
+    url = "https://github.com/deadlock-api/deadlock-api-ingest/releases/download/v${version}/deadlock-api-ingest-ubuntu-latest";
     sha256 = "sha256-bZIHTdhfX1UgH30i0+Sn2mAw7fNpg6OYBEr4oX+9P/8=="; 
   };
 

--- a/default.nix
+++ b/default.nix
@@ -1,27 +1,30 @@
 { pkgs ? import <nixpkgs> {} }:
 
-pkgs.rustPlatform.buildRustPackage rec {
+pkgs.stdenv.mkDerivation rec {
   pname = "deadlock-api-ingest";
-  version = "0.1.116-8f2cd8f";
+  version = "0.1.140-8659e00";
 
-  src = pkgs.fetchFromGitHub {
-    owner = "deadlock-api";
-    repo = "deadlock-api-ingest";
-    rev = "v${version}";
-    hash = "sha256-9h/+CsummSGA8GLfMJng/qRseZuQfrHzPCYNqRDt7C0=";
+  src = pkgs.fetchurl {
+    url = "https://github.com/deadlock-api/deadlock-api-ingest/releases/tag/v${version}/deadlock-api-ingest-ubuntu-latest";
+    sha256 = "sha256-bZIHTdhfX1UgH30i0+Sn2mAw7fNpg6OYBEr4oX+9P/8=="; 
   };
 
-  cargoHash = "sha256-iHhPe1rdk/nq0wFnKiG41QzMTOoeq6v583TyzXwHO0Q=";
-
-  doCheck = false; # compiles twice for a `cargo check`
-
   nativeBuildInputs = with pkgs; [
-    pkg-config
+    autoPatchelfHook
   ];
+
   buildInputs = with pkgs; [
     libpcap
-    openssl
+    libgcc
   ];
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 $src $out/bin/deadlock-api-ingest
+    patchelf --replace-needed libpcap.so.0.8 libpcap.so.1 $out/bin/deadlock-api-ingest
+  '';
 
   meta = {
     description = "A network packet capture tool that monitors HTTP traffic for Deadlock game replay files and ingests metadata to the Deadlock API.";

--- a/default.nix
+++ b/default.nix
@@ -2,16 +2,16 @@
 
 pkgs.rustPlatform.buildRustPackage rec {
   pname = "deadlock-api-ingest";
-  version = "0.1.102-fc2d778";
+  version = "0.1.116-8f2cd8f";
 
   src = pkgs.fetchFromGitHub {
     owner = "deadlock-api";
     repo = "deadlock-api-ingest";
     rev = "v${version}";
-    hash = "sha256-IXUUoWrXz/HZVkLZJ5vyMro9tboFW83q7zjUy4PLLrU=";
+    hash = "sha256-9h/+CsummSGA8GLfMJng/qRseZuQfrHzPCYNqRDt7C0=";
   };
 
-  cargoHash = "sha256-H61PDhu+zy641aKnxYT2cn9Cu2RHuWJQHaUz28nSAFk=";
+  cargoHash = "sha256-iHhPe1rdk/nq0wFnKiG41QzMTOoeq6v583TyzXwHO0Q=";
 
   doCheck = false; # compiles twice for a `cargo check`
 
@@ -31,4 +31,3 @@ pkgs.rustPlatform.buildRustPackage rec {
     mainProgram = "deadlock-api-ingest";
   };
 }
-

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.rustPlatform.buildRustPackage rec {
+  pname = "deadlock-api-ingest";
+  version = "0.1.102-fc2d778";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "deadlock-api";
+    repo = "deadlock-api-ingest";
+    rev = "v${version}";
+    hash = "sha256-IXUUoWrXz/HZVkLZJ5vyMro9tboFW83q7zjUy4PLLrU=";
+  };
+
+  cargoHash = "sha256-H61PDhu+zy641aKnxYT2cn9Cu2RHuWJQHaUz28nSAFk=";
+
+  doCheck = false; # compiles twice for a `cargo check`
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+  ];
+  buildInputs = with pkgs; [
+    libpcap
+    openssl
+  ];
+
+  meta = {
+    description = "A network packet capture tool that monitors HTTP traffic for Deadlock game replay files and ingests metadata to the Deadlock API.";
+    homepage = "https://github.com/deadlock-api/deadlock-api-ingest";
+    license = pkgs.lib.licenses.mit;
+    # maintainers = with pkgs.lib.maintainers; [ ];
+    mainProgram = "deadlock-api-ingest";
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758346548,
+        "narHash": "sha256-afXE7AJ7MY6wY1pg/Y6UPHNYPy5GtUKeBkrZZ/gC71E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b2a3852bd078e68dd2b3dfa8c00c67af1f0a7d20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A network packet capture tool that monitors HTTP traffic for Deadlock game replay files and ingests metadata to the Deadlock API.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05"; # Adjust if needed
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -12,9 +12,15 @@
         pkgs = import nixpkgs {
           inherit system;
         };
+
         package = import ./default.nix { inherit pkgs; };
       in {
+        apps.default = {
+          type = "app";
+          program = "${package}/bin/deadlock-api-ingest";
+        };
+
         packages.default = package;
+
       });
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "A network packet capture tool that monitors HTTP traffic for Deadlock game replay files and ingests metadata to the Deadlock API.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        package = import ./default.nix { inherit pkgs; };
+      in {
+        packages.default = package;
+      });
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
 
         package = import ./default.nix { inherit pkgs; };
       in {
+
         apps.default = {
           type = "app";
           program = "${package}/bin/deadlock-api-ingest";


### PR DESCRIPTION
This pull request adds basic support for running the program on Nix-based systems. Now users can build or run the binary with nix-build or nix run without having to manually handle dependencies.

### What's included

- `default.nix`: Main package for downloading and patching binary.
- `flake.nix`:  Flake support 
- `flake.lock`: Pins nixpkgs and flake-utils versions for reproducibility.


### ✅ Usage

#### ❄️ With Flakes

```
sudo nix run github:deadlock-api/deadlock-api-ingest
```

#### ❄️ Without Flakes 

Clone repository and run inside the folder
```
nix-build
```
Binary will be generated in ```/result/bin/deadlock-api-ingest```
