### PR TITLE
add ReadWritePaths=/var/log to updater service

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -379,6 +379,7 @@ StandardError=journal
 SyslogIdentifier=$UPDATE_SERVICE_NAME
 
 # Security Hardening
+ReadWritePaths=/var/log
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Noticed on boot that the deadlock-api-ingest-updater.service was failing. After looking into the issue I realized it was from the file system protection added to the service preventing the updater from writing to the log file.

Fixed by allowing the /var/log directory to be written to.

## Related Issue
<!-- Link to the related issue (if applicable) -->
N/A

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Other (please describe):

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
N/A

## Additional Notes
<!-- Add any other context about the PR here -->
Could narrow the scope of access by moving the log file to a sub directory under /var/log but I'll leave that up to you.
