### PR TITLE
fix: add a check for a one drive shortcut and remove from there if it exists

### DIFF
--- a/uninstall-windows.ps1
+++ b/uninstall-windows.ps1
@@ -59,17 +59,15 @@ if ($processes) {
 
 # Remove desktop shortcuts
 Write-Host "Removing desktop shortcuts..." -ForegroundColor Cyan
-$shortcuts = Get-Item "$env:USERPROFILE\Desktop\$AppName*.lnk" -ErrorAction SilentlyContinue
-$oneDriveShortcuts = Get-Item "$env:USERPROFILE\OneDrive\Desktop\$AppName*.lnk" -ErrorAction SilentlyContinue
-if ($shortcuts || $oneDriveShortcuts) {
-    Write-Host "  - Removing $(@($shortcuts).Count) shortcut(s)" -ForegroundColor Gray
-}
+$shortcutPaths = @(
+    "$env:USERPROFILE\Desktop\$AppName*.lnk",
+    "$env:USERPROFILE\OneDrive\Desktop\$AppName*.lnk"
+)
 
-if ($shortcuts) {
-    Remove-Item "$env:USERPROFILE\Desktop\$AppName*.lnk" -Force -ErrorAction SilentlyContinue
-}
-if ($oneDriveShortcuts) {
-    Remove-Item "$env:USERPROFILE\OneDrive\Desktop\$AppName*.lnk" -Force -ErrorAction SilentlyContinue
+$allShortcuts = $shortcutPaths | ForEach-Object { Get-Item $_ -ErrorAction SilentlyContinue }
+if ($allShortcuts) {
+    Write-Host "  - Removing $(@($allShortcuts).Count) shortcut(s)" -ForegroundColor Gray
+    $shortcutPaths | ForEach-Object { Remove-Item $_ -Force -ErrorAction SilentlyContinue }
 }
 
 # Remove installation directory


### PR DESCRIPTION
This pull request updates the uninstall script to ensure that desktop shortcuts are removed from both the local Desktop and OneDrive Desktop folders, improving the thoroughness of the uninstallation process.

Shortcut removal improvements:

* The script now checks for and removes shortcuts from both the user's local `Desktop` folder and the `OneDrive\Desktop` folder, ensuring all possible desktop shortcuts for the application are deleted.