### PR TITLE
feat: add launch wrapper mode for Steam launch options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +100,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cookie"
@@ -114,6 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 name = "deadlock-api-ingest"
 version = "0.2.7"
 dependencies = [
+ "clap",
  "dirs",
  "memchr",
  "notify",
@@ -226,6 +323,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
@@ -383,6 +486,12 @@ checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -571,6 +680,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -802,6 +917,12 @@ dependencies = [
  "serde",
  "winreg 0.55.0",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1069,6 +1190,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deadlock-api-ingest"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.6.0", features = ["derive"] }
 ureq = { version = "3.3.0", default-features = false, features = ["json", "rustls"] }
 memchr = "2.8.0"
 notify = "8.2.0"
@@ -16,7 +17,7 @@ steamlocate = "2.0.1"
 dirs = "6.0.0"
 walkdir = "2.5.0"
 tracing = "0.1.44"
-tracing-appender = "0.2"
+tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadlock-api-ingest"
-version = "0.2.7"
+version = "0.2.8"
 description = "Deadlock API Ingest"
 repository = "https://github.com/deadlock-api/deadlock-api-ingest"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ systemd.user.services.deadlock-api-ingest = {
 
 Then enable: `systemctl --user enable --now deadlock-api-ingest`
 
+## Steam Launch Option (Alternative to Background Service)
+
+Instead of running the ingest service as a persistent background process, you can configure it to run only while Deadlock is active by using Steam's launch options. The service will start when you launch the game and automatically stop when the game exits.
+
+1. Download the binary to a known location (e.g., `~/.local/bin/deadlock-api-ingest` on Linux or `%LOCALAPPDATA%\deadlock-api-ingest\deadlock-api-ingest.exe` on Windows)
+2. In Steam, right-click **Deadlock** → **Properties** → **General** → **Launch Options**
+3. Set the launch option:
+
+**Linux:**
+```
+/home/YOUR_USER/.local/bin/deadlock-api-ingest -- %command%
+```
+
+**Windows:**
+```
+"C:\Users\YOUR_USER\AppData\Local\deadlock-api-ingest\deadlock-api-ingest.exe" -- %command%
+```
+
+You can also combine it with existing flags:
+```
+deadlock-api-ingest --no-statlocker -- %command%
+```
+
+> **Note:** If you use this approach, you should disable or remove any existing background service (systemd, Task Scheduler, etc.) to avoid running two instances simultaneously.
+
 ## Uninstallation
 
 ### Windows

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,31 @@
 
 use std::path::PathBuf;
 
+use clap::Parser;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+
+/// Deadlock API Ingest — uploads match data from Steam's HTTP cache.
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    /// Disable statlocker integration
+    #[arg(long)]
+    no_statlocker: bool,
+
+    /// Ingest once and exit (no file watching)
+    #[arg(long)]
+    once: bool,
+
+    /// Game command to wrap (launch wrapper mode).
+    /// When provided, the watcher runs in the background while the game
+    /// runs as a child process, and exits when the game exits.
+    /// Usage: deadlock-api-ingest -- %command%
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    command: Vec<String>,
+}
 
 mod error;
 mod ingestion_cache;
@@ -64,11 +85,13 @@ fn init_tracing() {
 fn main() {
     init_tracing();
 
+    let args = Args::parse();
+
     if let Some(log_dir) = get_log_dir() {
         info!("Log files are being written to: {}", log_dir.display());
     }
 
-    if std::env::args().any(|arg| arg == "--no-statlocker") {
+    if args.no_statlocker {
         statlocker::disable();
     }
 
@@ -111,8 +134,32 @@ fn main() {
 
     scan_cache::initial_cache_dir_ingest(&cache_dir);
 
-    if std::env::args().any(|arg| arg == "--once") {
+    if args.once {
         std::process::exit(0);
+    }
+
+    // Launch wrapper mode: start watcher in background, run game, exit when game exits
+    if !args.command.is_empty() {
+        std::thread::spawn(move || {
+            loop {
+                if let Err(e) = scan_cache::watch_cache_dir(&cache_dir) {
+                    warn!("Error in cache watcher: {e:?}");
+                }
+                std::thread::sleep(core::time::Duration::from_secs(10));
+            }
+        });
+
+        info!("Launching game: {}", args.command.join(" "));
+        let status = std::process::Command::new(&args.command[0])
+            .args(&args.command[1..])
+            .status();
+
+        match &status {
+            Ok(s) => info!("Game exited with status: {s}"),
+            Err(e) => error!("Failed to launch game command '{}': {e}", args.command[0]),
+        }
+
+        std::process::exit(status.map_or(1, |s| s.code().unwrap_or(0)));
     }
 
     loop {


### PR DESCRIPTION
Allow the ingest service to be used as a Steam launch command wrapper
(e.g. `deadlock-api-ingest %command%`) so it only runs while the game
is active and stops when the game exits.

This adds a new mode where non-flag arguments are treated as the game
command to execute. The ingest service runs in a background thread and
gracefully shuts down when the game process exits, propagating the
game's exit code.

Closes #75